### PR TITLE
support refinement of POSITION in EDPluginGroupXDS

### DIFF
--- a/mxPluginExec/plugins/EDPluginGroupXDS-v1.0/plugins/xdscfgformat.py
+++ b/mxPluginExec/plugins/EDPluginGroupXDS-v1.0/plugins/xdscfgformat.py
@@ -87,7 +87,7 @@ class BoundedList(object):
 
 class RefineJobs(Enumeration):
     def __init__(self):
-        JOBS = [ 'ALL', 'DISTANCE', 'BEAM',
+        JOBS = [ 'ALL', 'DISTANCE', 'BEAM', 'POSITION',
                 'AXIS', 'ORIENTATION', 'CELL']
 
         Enumeration.__init__(self, JOBS, default='ALL')


### PR DESCRIPTION
The fix is for the error msg (see below) when having POSITION in refinement, i.e. REFINE(INTEGRATE)= POSITION in XDS.INP. 
    File "/mxn/groups/biomax/cmxsoft/edna-mx_new/mxPluginExec/plugins/EDPluginGroupXDS-v1.0/plugins/xdscfgformat.py", line 60, in __call__
      raise ValueError("val %s not in %s" % (val, self.possible_values))
  ValueError: val POSITION not in ['ALL', 'DISTANCE', 'BEAM', 'AXIS', 'ORIENTATION', 'CELL']

