### PR TITLE
bug fix - wrong eiger filerNumber if imageNumber is not a multiple of 100

### DIFF
--- a/kernel/src/EDUtilsPath.py
+++ b/kernel/src/EDUtilsPath.py
@@ -179,6 +179,16 @@ class EDUtilsPath:
             return cls._EDNA_SITE.startswith('ESRF')
 
     @classmethod
+    def isMAXIV(cls):
+        """
+        Returns true if MAXIV config
+        """
+        if cls._EDNA_SITE is None:
+            return False
+        else:
+            return cls._EDNA_SITE.startswith('MAXIV')
+
+    @classmethod
     def getCwd(cls):
         """
         Returns the current directory.

--- a/mxPluginExec/plugins/EDPluginAutoPROC-v1.0/plugins/EDPluginExecAutoPROCv1_0.py
+++ b/mxPluginExec/plugins/EDPluginAutoPROC-v1.0/plugins/EDPluginExecAutoPROCv1_0.py
@@ -49,6 +49,7 @@ class EDPluginExecAutoPROCv1_0(EDPluginExecProcessScript):
         self.setXSDataInputClass(XSDataInputAutoPROC)
         self.setDataOutput(XSDataResultAutoPROC())
         self.maxNoProcessors = 12
+        self.maxNoJobs = None
         self.pathToNeggiaPlugin = None
         self.doScaleWithXscale = False
         self.rotationAxis = None
@@ -65,6 +66,7 @@ class EDPluginExecAutoPROCv1_0(EDPluginExecProcessScript):
         EDPluginExecProcessScript.configure(self)
         self.DEBUG("EDPluginExecAutoPROCv1_0.configure")
         self.maxNoProcessors = self.config.get("maxNoProcessors", self.maxNoProcessors)
+        self.maxNoJobs = self.config.get("maxNoJobs", self.maxNoJobs)
         self.pathToNeggiaPlugin = self.config.get("pathToNeggiaPlugin")
         self.doScaleWithXscale = self.config.get("scaleWithXscale", self.doScaleWithXscale)
         self.rotationAxis = self.config.get("rotationAxis", self.rotationAxis)
@@ -119,6 +121,8 @@ class EDPluginExecAutoPROCv1_0(EDPluginExecProcessScript):
         self.DEBUG("EDPluginExecAutoPROCv1_0.generateCommands")
         strCommandText = "-B -xml -nthreads {0} -M ReportingInlined autoPROC_HIGHLIGHT=\"no\"".format(self.maxNoProcessors)
 
+        if self.maxNoJobs is not None:
+            strCommandText += " autoPROC_XdsKeyword_MAXIMUM_NUMBER_OF_JOBS={0}".format(self.maxNoJobs)
         if self.doScaleWithXscale:
             strCommandText += " autoPROC_ScaleWithXscale='yes'"
 

--- a/mxPluginExec/plugins/EDPluginGroupXDS-v1.0/plugins/EDPluginExecMinimalXdsv1_0.py
+++ b/mxPluginExec/plugins/EDPluginGroupXDS-v1.0/plugins/EDPluginExecMinimalXdsv1_0.py
@@ -214,9 +214,10 @@ class EDPluginExecMinimalXdsv1_0(EDPluginExecProcessScript):
             parsed_config["LIB="] = self.pathToNeggiaPlugin
 
         # Max no processors
-        if not EDUtilsPath.isEMBL():
+        if not EDUtilsPath.isEMBL() and not EDUtilsPath.isMAXIV():
             parsed_config['MAXIMUM_NUMBER_OF_PROCESSORS='] = str(self.maxNoProcessors)
-        parsed_config['MAXIMUM_NUMBER_OF_JOBS='] = 1
+        if not EDUtilsPath.isMAXIV():
+            parsed_config['MAXIMUM_NUMBER_OF_JOBS='] = 1
 
         # Save back the changes
         dump_xds_file(xds_file, parsed_config)

--- a/mxv1/plugins/EDPluginControlAutoPROC-v1.0/plugins/EDPluginControlAutoPROCv1_0.py
+++ b/mxv1/plugins/EDPluginControlAutoPROC-v1.0/plugins/EDPluginControlAutoPROCv1_0.py
@@ -172,6 +172,8 @@ class EDPluginControlAutoPROCv1_0(EDPluginControl):
             directory = ispybDataCollection.imageDirectory
             if EDUtilsPath.isEMBL():
                 template = ispybDataCollection.fileTemplate.replace("%05d", "#" * 5)
+            elif EDUtilsPath.isMAXIV():
+                template = ispybDataCollection.fileTemplate
             else:
                 template = ispybDataCollection.fileTemplate.replace("%04d", "####")
             if self.dataInput.fromN is None:
@@ -273,6 +275,14 @@ class EDPluginControlAutoPROCv1_0(EDPluginControl):
             minSizeFirst = 2000000
             minSizeLast = 2000000
         elif any(beamline in pathToStartImage for beamline in ["id30a3"]):
+            minSizeFirst = 100000
+            minSizeLast = 100000
+            pathToStartImage = os.path.join(directory,
+                                            self.eiger_template_to_image(template, imageNoStart))
+            pathToEndImage = os.path.join(directory,
+                                          self.eiger_template_to_image(template, imageNoEnd))
+            isH5 = True
+        elif EDUtilsPath.isMAXIV():
             minSizeFirst = 100000
             minSizeLast = 100000
             pathToStartImage = os.path.join(directory,
@@ -678,11 +688,17 @@ class EDPluginControlAutoPROCv1_0(EDPluginControl):
     def eiger_template_to_image(self, fmt, num):
         import math
         fileNumber = int(math.ceil(num / 100.0))
-        fmt_string = fmt.replace("####", "1_data_%06d" % fileNumber)
+        if EDUtilsPath.isMAXIV():
+            fmt_string = fmt.replace("%06d", "data_%06d" % fileNumber)
+        else:
+            fmt_string = fmt.replace("####", "1_data_%06d" % fileNumber)
         return fmt_string.format(num)
 
     def eiger_template_to_master(self, fmt):
-        fmt_string = fmt.replace("####", "1_master")
+        if EDUtilsPath.isMAXIV():
+            fmt_string = fmt.replace("%06d", "master")
+        else:
+            fmt_string = fmt.replace("####", "1_master")
         return fmt_string
 
     def matchesTruncateEarlyLate(self, fileName):

--- a/mxv1/plugins/EDPluginControlAutoPROC-v1.0/plugins/EDPluginControlAutoPROCv1_0.py
+++ b/mxv1/plugins/EDPluginControlAutoPROC-v1.0/plugins/EDPluginControlAutoPROCv1_0.py
@@ -676,9 +676,8 @@ class EDPluginControlAutoPROCv1_0(EDPluginControl):
 
 
     def eiger_template_to_image(self, fmt, num):
-        fileNumber = int(num / 100)
-        if fileNumber == 0:
-            fileNumber = 1
+        import math
+        fileNumber = int(math.ceil(num / 100.0))
         fmt_string = fmt.replace("####", "1_data_%06d" % fileNumber)
         return fmt_string.format(num)
 

--- a/mxv1/plugins/EDPluginControlEDNAproc-v1.0/plugins/EDPluginControlEDNAprocv1_0.py
+++ b/mxv1/plugins/EDPluginControlEDNAproc-v1.0/plugins/EDPluginControlEDNAprocv1_0.py
@@ -1269,6 +1269,9 @@ class EDPluginControlEDNAprocv1_0(EDPluginControl):
                         year = tokens[4][0:4]
                         pyarch_path = os.path.join('/data/pyarch', year, tokens[1],
                                                    *tokens[3:])
+            elif EDUtilsPath.isMAXIV():
+                pyarch_path =  files_dir.replace("/data","/mxn/groups/ispybstorage",1)
+
             if pyarch_path is not None:
                 pyarch_path = pyarch_path.replace('PROCESSED_DATA', 'RAW_DATA')
                 try:

--- a/mxv1/plugins/EDPluginControlEDNAproc-v1.0/plugins/EDPluginControlRunXdsv1_0.py
+++ b/mxv1/plugins/EDPluginControlEDNAproc-v1.0/plugins/EDPluginControlRunXdsv1_0.py
@@ -31,6 +31,7 @@ import os.path
 
 from EDPluginControl import EDPluginControl
 from EDVerbose import EDVerbose
+from EDUtilsPath import EDUtilsPath
 
 from XSDataCommon import XSDataFile, XSDataString
 
@@ -119,8 +120,9 @@ class EDPluginControlRunXdsv1_0(EDPluginControl):
             params = XSDataMinimalXdsIn()
             params.input_file = self.dataInput.input_file
             params.jobs = 'ALL'
-            params.maxprocs = 4
-            params.maxjobs = 1
+            if not EDUtilsPath.isMAXIV():
+                params.maxprocs = 4
+                params.maxjobs = 1
             self.third_run.dataInput = params
             self.third_run.executeSynchronous()
 
@@ -138,8 +140,9 @@ class EDPluginControlRunXdsv1_0(EDPluginControl):
             params = XSDataMinimalXdsIn()
             params.input_file = self.dataInput.input_file
             params.jobs = 'DEFPIX INTEGRATE CORRECT'
-            params.maxprocs = 4
-            params.maxjobs = 1
+            if not EDUtilsPath.isMAXIV():
+                params.maxprocs = 4
+                params.maxjobs = 1
             self.final_run.dataInput = params
             self.final_run.executeSynchronous()
 

--- a/mxv1/src/EDHandlerESRFPyarchv1_0.py
+++ b/mxv1/src/EDHandlerESRFPyarchv1_0.py
@@ -60,6 +60,9 @@ class EDHandlerESRFPyarchv1_0:
                                                     *listOfDirectories[4:])
             return strPyarchDNAFilePath
 
+        if EDUtilsPath.isMAXIV():
+            strPyarchDNAFilePath =  _strESRFPath.replace("/data","/mxn/groups/ispybstorage",1)
+            return strPyarchDNAFilePath
 
         listBeamlines = ["bm30a", "id14eh1", "id14eh2", "id14eh3", "id14eh4", "id23eh1", "id23eh2",
                          "id29", "id30a1", "id30a2", "id30a3", "id30b", "simulator_mxcube"]


### PR DESCRIPTION
When the image number is not a multiple of 100, say 120 or 360, the calculate fileNumber is one less than the actual number.